### PR TITLE
Fix: gen.py - Ensure npm is found on Windows

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Final
 import pexpect
+from pexpect import popen_spawn
 import shutil
 import click
 import sys
@@ -46,9 +47,10 @@ def dev(work_dir: str = './', kit_dir: str = ANALYKIT_RELPATH, npm_registry: str
             shutil.copy(src_path, target)
 
     os.chdir(work_dir)
-    cmd = f'npm install {"--registry=" + npm_registry if npm_registry else ""}'
+    cmd_prefix = 'cmd.exe /c ' if sys.platform == 'win32' else ''
+    cmd = f'{cmd_prefix}npm install {"--registry=" + npm_registry if npm_registry else ""}'
     print(cmd)
-    npmsh = pexpect.spawn(cmd, logfile=sys.stdout.buffer)
+    npmsh = popen_spawn.PopenSpawn(cmd, logfile=sys.stdout.buffer)
     npmsh.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=60)
 
 


### PR DESCRIPTION
在 Windows运行 `python frida-analykit/gen.py dev` 时，如果 `npm` 的安装路径没有被正确添加到 Python 进程可访问的 `PATH` 环境变量中，`npm install` 步骤会因为 `FileNotFoundError: [WinError 2] 系统找不到指定的文件。` 而失败。

## 解决方案 (The Solution)

修改了 `gen.py` 脚本，在 Windows 平台上执行 `npm install` 命令时，在命令前添加 `cmd.exe /c `。